### PR TITLE
Fix workflow run promise awaiting, so that workers exit cleanly

### DIFF
--- a/lib/temporal.explorer.ts
+++ b/lib/temporal.explorer.ts
@@ -52,7 +52,7 @@ export class TemporalExplorer
   }
 
   onApplicationBootstrap() {
-    this.workerRunPromise = this.worker.run();
+    this.workerRunPromise = this.worker?.run();
   }
 
   async explore() {


### PR DESCRIPTION
Per https://community.temporal.io/t/connection-retry-for-temporal/10992 and https://typescript.temporal.io/api/classes/worker.Worker#run, the API for worker exits is:
* Call `this.worker.shutdown`
* Wait for the promise originally returned by `worker.run()` to return, handling errors appropriately